### PR TITLE
Change UpdateUrl to raw version file

### DIFF
--- a/KeepassAutoUnlock/KeepassAutoUnlockExt.cs
+++ b/KeepassAutoUnlock/KeepassAutoUnlockExt.cs
@@ -20,7 +20,7 @@ namespace KeePassAutoUnlock
         {
             get
             {
-                return "https://github.com/jeremy-bourgin/KeePassAutoUnlock/blob/master/versionInfo.txt";
+                return "https://raw.githubusercontent.com/jeremy-bourgin/KeePassAutoUnlock/master/versionInfo.txt";
             }
         }
 


### PR DESCRIPTION
Fixes #7.
The original url goes to the github wrapper for the file. KeePass cannot handle this and fails the update check. Linking to the raw version should fix this issue.